### PR TITLE
Add prerelease test for pull requests

### DIFF
--- a/.github/workflows/industrial_ci_prerelease.yml
+++ b/.github/workflows/industrial_ci_prerelease.yml
@@ -1,0 +1,15 @@
+name: CI prerelease
+
+on: pull_request
+
+jobs:
+  prerelease:
+    name: "Build + Test with package dependencies with Testing Repo of noetic (http://packages.ros.org/ros-testing/ubuntu)"
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v1
+      - uses: 'ros-industrial/industrial_ci@master'
+        env:
+          PRERELEASE: true
+          ROS_REPO: testing
+          ROS_DISTRO: noetic


### PR DESCRIPTION
Since this repo mainly contains utilities which are used by other packages, a prerelease test should be very useful.