### PR TITLE
Add missing header in service_client_mock.h

### DIFF
--- a/pilz_testutils/include/pilz_testutils/service_client_mock.h
+++ b/pilz_testutils/include/pilz_testutils/service_client_mock.h
@@ -23,6 +23,8 @@
 
 #include <gmock/gmock.h>
 
+#include <ros/console.h>
+
 namespace pilz_testutils
 {
 /**


### PR DESCRIPTION
## Description
This header is needed for `ROS_DEBUG_NAMED`