### PR TITLE
JointStatePublisherMock stop publishing in DTOR

### DIFF
--- a/pilz_testutils/include/pilz_testutils/joint_state_publisher_mock.h
+++ b/pilz_testutils/include/pilz_testutils/joint_state_publisher_mock.h
@@ -43,6 +43,11 @@ class JointStatePublisherMock
 public:
   JointStatePublisherMock();
 
+  ~JointStatePublisherMock();
+
+  JointStatePublisherMock(const JointStatePublisherMock& other) = delete;
+  JointStatePublisherMock& operator=(const JointStatePublisherMock& other) = delete;
+
   void startPublishingAsync(const double& joint1_start_position = 0.0);
 
   void setJoint1Velocity(const double& vel);

--- a/pilz_testutils/src/joint_state_publisher_mock.cpp
+++ b/pilz_testutils/src/joint_state_publisher_mock.cpp
@@ -42,6 +42,11 @@ JointStatePublisherMock::JointStatePublisherMock()
   pub_ = nh_.advertise<JointState>(nh_.getNamespace() + "/" + JOINT_STATES_TOPIC_NAME, JOINT_STATES_QUEUE_SIZE);
 }
 
+JointStatePublisherMock::~JointStatePublisherMock()
+{
+  stopPublishing();
+}
+
 void JointStatePublisherMock::startPublishingAsync(const double& joint1_start_position)
 {
   stop_flag_ = false;


### PR DESCRIPTION
## Description

If the JointStatePublisherMock is destructed in the test it should stop publishing.

I noticed this when
```
TEST_F(JointStatePublisherMockTest, defaultBehaviour)
{
  JointStatePublisherMock publisher_mock;
  publisher_mock.startPublishingAsync();

  pilz_utils::waitForMessage<sensor_msgs::JointState>("/joint_states");
}
```
immediatly crashed. It only works if I add `publisher_mock.stopPublishing()` at the end. This does not seem very intuitiv to me.

### Things to add, update or check by the maintainers before this PR can be merged.

* [ ] Public api function documentation
* [ ] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))
* [ ] CHANGELOG.rst updated
* [ ] Copyright headers

### Review Checklist
* [ ] Soft- and hardware architecture (diagrams and description)
* [ ] Test review (test plan and individual test cases)
* [ ] Documentation describes purpose of file(s) and responsibilities
* [ ] Code (coding rules, style guide)

### Release planning (please answer)
* [ ] When is the new feature released?
* [ ] Which dependent packages do have to be released simultaneously?
