### PR TITLE
Increase minimum cmake version.

### DIFF
--- a/pilz_industrial_motion_testutils/CMakeLists.txt
+++ b/pilz_industrial_motion_testutils/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(pilz_industrial_motion_testutils)
 
 find_package(catkin REQUIRED)

--- a/pilz_msgs/CMakeLists.txt
+++ b/pilz_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(pilz_msgs)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/pilz_testutils/CMakeLists.txt
+++ b/pilz_testutils/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(pilz_testutils)
 
 add_definitions(-std=c++14)

--- a/pilz_utils/CMakeLists.txt
+++ b/pilz_utils/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(pilz_utils)
 
 ## Compile as C++11, supported in ROS Kinetic and newer


### PR DESCRIPTION
Fixes deprecation warning of cmake policy CMP0048.

See https://build.ros.org/job/Ndev_db__pilz_common__debian_buster_amd64/8/


